### PR TITLE
JS에서 TS로 마이그레이션 진행

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,0 +1,10 @@
+declare module "toDo" {
+  interface Item {
+    id: number;
+    content: string;
+    isCompleted: boolean;
+    category: string;
+    tags?: string[];
+  }
+  type SelectedId = Item['id'];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*", "types/index.d.ts"],
+  "include": ["src/**/*", "@types/index.d.ts"],
 
   "compilerOptions": {
     /* Language and Environment */
@@ -8,7 +8,7 @@
     /* Type Checking */
     "strict": true, /* Enable all strict type-checking options. */
     "strictNullChecks": true, /* 구체적인 값이 예상되는 곳에서 null이나 undefined를 사용하려고 하면 에러가 발생합니다. */
-    "typeRoots": ["types"],
+    "typeRoots": ["@types"],
     /* Emit */
     "declaration": true, /* Generate .d.ts files for every TypeScript or JavaScript file inside your project. */
     /* Module */


### PR DESCRIPTION
## 작업내용
types 디렉토리명 앞에 @ 추가했습니다. 
@를 붙이지 않아도 잘 작동되지만 바꾼 이유는, 공식문서의 module d.ts 선언 예문을 보면, 디렉토리명앞에 @types 를 넣어서 표기하기 때문입니다. (예문 아래 첨부)
관습적으로 디렉토리명 앞에 @을 붙이는 것 같은데 정확한 이유는 모르겠습니다. node_modules/@types와 맞추려고 쓴 것 같다는 추측을 하고 있습니다... (나중에 알게되면 정리)

```
@types/myLib
  +---- index.d.ts
  +---- foo.d.ts
  +---- bar
         +---- index.d.ts
         +---- baz.d.ts
```
[예문](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html)

## .d.ts (Declaration files)란
d.ts 파일을 생성하면 (기존에 node_modules/@types에 있는 타입을 가져다 쓰는게 아니라, ) 직접 커스텀 타입을 선언하여 사용할 수 있습니다.

우리가 만든 커스텀 타입을 인식시키기 위해서는 tsconfig의 compilerOptions에 typeRoots 속성을 추가해야 합니다.
typeRoots를 지정하면, 컴파일러가 node_modules/@types가 아니라 지정해준 커스텀 타입을 인식합니다.

## Reference
이슈 https://github.com/sukyoungshin/wanted-pre-onboarding-challenge-fe-2/issues/1
[TS공식문서 declaration-files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
[코딩하는 경제학도](https://ssocoit.tistory.com/253)
